### PR TITLE
Initial build for 2.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,38 +7,54 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sklearn-pandas-{{ version }}.tar.gz
-  sha256: bf908ea0e384e132da04355c7db67bd4f8efe145f0c9cd9f14726ce899d27542
+  # Using GH to get the tests.
+  url: https://github.com/scikit-learn-contrib/sklearn-pandas/archive/refs/tags/v2.2.0.tar.gz
+  sha256: 33b5ac5f18ebbde9798944357db0af1289986e502763fc0f8392c31d62af1961
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -v --no-deps --no-build-isolation
+  skip: true  # [py<38]
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.7
-    - scikit-learn >=0.23.0
+    - python
+    # Some tests fail with scikit-learn>=1.2
+    - scikit-learn >=0.23.0,<1.2
     - scipy >=1.5.1
     - pandas >=1.1.4
     - numpy >=1.18.1
 
 test:
+  source_files:
+    - tests
   imports:
     - sklearn_pandas
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
+    - python
+    - pytest
 
 about:
   home: https://github.com/scikit-learn-contrib/sklearn-pandas
   summary: Pandas integration with sklearn
+  description: >
+    This module provides a bridge between Scikit-Learn's machine learning methods and
+    pandas-style Data Frames. In particular, it provides a way to map DataFrame columns
+    to transformations, which are later recombined into features
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
+  dev_url: https://github.com/scikit-learn-contrib/sklearn-pandas
+  doc_url: https://github.com/scikit-learn-contrib/sklearn-pandas
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,9 @@ test:
     - sklearn_pandas
   commands:
     - pip check
-    - pytest -v tests
+    - pytest -v tests  # [not win]
+    # Skipping test_numerical_transformer_serialization due to permission issues on Windows.
+    - pytest -v tests -k "not test_numerical_transformer_serialization"  # [win]
   requires:
     - pip
     - python


### PR DESCRIPTION
sklearn-pandas 2.2.0

**Destination channel:** defaults

### Links

- [PKG-3919](https://anaconda.atlassian.net/browse/PKG-3919)
- [Upstream repository](https://github.com/scikit-learn-contrib/sklearn-pandas/tree/v2.2.0)

### Explanation of changes:

Initial build.

[PKG-3919]: https://anaconda.atlassian.net/browse/PKG-3919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ